### PR TITLE
Update for new newScope signature

### DIFF
--- a/docs/src/HTTP11.md
+++ b/docs/src/HTTP11.md
@@ -49,7 +49,7 @@ the connection has been closed:
 covering
 serve : Socket AF_INET -> Async Poll [] ()
 serve cli = Prelude.do
-  (sc,_) <- newScope
+  sc <- newScope
   guarantee (tillFalse sc) (close' cli)
 
   where


### PR DESCRIPTION
`newScope` now just returns a `Scope` rather than a pair.